### PR TITLE
add support for easily embedding commbadge into other apps (bug 907569)

### DIFF
--- a/src/media/css/comm.styl
+++ b/src/media/css/comm.styl
@@ -55,6 +55,9 @@ tick() {
     .note-count {
         font-size: 38px;
         line-height: 42px;
+        a {
+            color: $black;
+        }
     }
     .thread-meta {
         float: left;

--- a/src/templates/_macros/thread.html
+++ b/src/templates/_macros/thread.html
@@ -9,7 +9,9 @@
               {{ t.addon_meta.name }}
             </div>
           </a>
-          <h3 class="note-count" data-count="{{ t.notes_count }}">{{ _plural('{n} note', '{n} notes', n=t.notes_count) }}</h3>
+          <h3 class="note-count" data-count="{{ t.notes_count }}">
+            <a href="{{ url('show_thread', [t.id]) }}">{{ _plural('{n} note', '{n} notes', n=t.notes_count) }}</a>
+          </h3>
         </div>
         <div class="thread-action">
           <button class="button alt reply open-reply">{{ _('Respond') }}</button>


### PR DESCRIPTION
Add some settings to specify which elements are the `body` and main `page`.

Allow URLs to be attached on top of other URLs by making them non-rooted. (eg. http://blah.com/foo/bar/gaz/comm)
