### PR TITLE
switch to recent tab after posting note (bug 918779)

### DIFF
--- a/src/media/css/comm.styl
+++ b/src/media/css/comm.styl
@@ -113,6 +113,7 @@ tick() {
 }
 
 .notes-container {
+    background-color: lighten(blue, 98%);
     padding: 0;
 
     & > div {

--- a/src/media/js/views/comm.js
+++ b/src/media/js/views/comm.js
@@ -21,6 +21,7 @@ define('views/comm',
             var $threadElem = $threadItem.find('.thread-header');
 
             // Add a new note element.
+            $threadElem.find('.filter-recent').trigger('click');
             var noteMarkup = nunjucks.env.getTemplate('comm/note_detail.html').render({note: data});
             var $noteCount = $threadElem.find('.note-count');
             var count = $noteCount.data('count') + 1;


### PR DESCRIPTION
When posting a reply, the note would be prepended to the current tab, which could be the `READ` tab.

Switch the the `RECENT` tab and prepend the note there.
