### PR TITLE
move view older btn into container

### DIFF
--- a/src/media/css/comm.styl
+++ b/src/media/css/comm.styl
@@ -115,6 +115,7 @@ tick() {
 .notes-container {
     background-color: lighten(blue, 98%);
     padding: 0;
+    padding-bottom: 12px;
 
     & > div {
         padding: 10px;

--- a/src/templates/_macros/thread.html
+++ b/src/templates/_macros/thread.html
@@ -42,8 +42,6 @@
       {% for note in t.recent_notes %}
         {% include 'comm/note_detail.html' %}
       {% endfor %}
-    </section>
-    <section class="fixed-end">
       {% if t.notes_count > t.recent_notes.length %}
         <button class="button alt view-older-notes">{{ _('View older') }}</button>
       {% endif %}


### PR DESCRIPTION
Group the button into the container with the rest of its stuff. Got confused why there were "View older" buttons floating in space between threads.
## Before

![screen shot 2013-10-09 at 11 47 25 am](https://f.cloud.github.com/assets/674727/1300526/4a081498-3113-11e3-8353-73a3a754c82e.png)
## After

![screen shot 2013-10-09 at 11 47 11 am](https://f.cloud.github.com/assets/674727/1300527/4afcd23a-3113-11e3-926c-f4de1c4c2536.png)
